### PR TITLE
Event-driven implementation to reduce CPU usage

### DIFF
--- a/mute_it/NotificationClient.cs
+++ b/mute_it/NotificationClient.cs
@@ -17,7 +17,7 @@ class NotificationClient: NAudio.CoreAudioApi.Interfaces.IMMNotificationClient
 
     public void OnDefaultDeviceChanged(DataFlow dataFlow, Role deviceRole, string defaultDeviceId)
     {
-        // context.updatePrimaryMicDevice();
+        context.updatePrimaryMicDevice();
     }
 
     public void OnDeviceAdded(string deviceId)

--- a/mute_it/NotificationClient.cs
+++ b/mute_it/NotificationClient.cs
@@ -1,0 +1,42 @@
+using System;
+using NAudio.CoreAudioApi;
+using mute_it;
+
+class NotificationClient: NAudio.CoreAudioApi.Interfaces.IMMNotificationClient
+{
+    private MuteItContext context;
+
+    public NotificationClient(MuteItContext context)
+    {
+        if (Environment.OSVersion.Version.Major < 6)
+        {
+            throw new NotSupportedException("This feature requires Windows Vista or newer");
+        }
+        this.context = context;
+    }
+
+    public void OnDefaultDeviceChanged(DataFlow dataFlow, Role deviceRole, string defaultDeviceId)
+    {
+        // context.updatePrimaryMicDevice();
+    }
+
+    public void OnDeviceAdded(string deviceId)
+    {
+        // Nothing to do
+    }
+
+    public void OnDeviceRemoved(string deviceId)
+    {
+        // Nothing to do
+    }
+
+    public void OnDeviceStateChanged(string deviceId, DeviceState newState)
+    {
+        // Nothing to do
+    }
+
+    public void OnPropertyValueChanged(string deviceId, PropertyKey propertyKey)
+    {
+        // Nothing to do
+    }
+}

--- a/mute_it/mute_it.csproj
+++ b/mute_it/mute_it.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="HotkeyManager.cs" />
     <Compile Include="MuteItContext.cs" />
+    <Compile Include="NotificationClient.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">


### PR DESCRIPTION
The goal of this change is to reduce CPU usage by replacing the periodic active polling method used to monitor the microphone status by an event-driven mechanism which updates the status only when the default (primary) mic device changes or when there is a volume change event on the current primary mic device.